### PR TITLE
Bind server to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Everything is powered by Node.js, so no Python runtime is required.
    ```sh
    node server.js
    ```
-   The page will be available at <http://localhost:3000>.
+   The page will be available at <http://127.0.0.1:3000>.
+   By binding only to the local interface the Windows firewall prompt is
+   avoided.
 
 During development the app serves images from the folder `~/clocl_wallpapers`.
 If the directory does not exist it will be created automatically. Place any

--- a/main.js
+++ b/main.js
@@ -8,9 +8,10 @@ let serverInstance;
 
 function createWindow() {
   const port = process.env.PORT || 3000;
+  const host = '127.0.0.1';
   const appDir = path.join(__dirname, 'public');
   const staticDir = path.join(os.homedir(), 'clocl_wallpapers');
-  serverInstance = startServer({ port, appDir, staticDir });
+  serverInstance = startServer({ port, host, appDir, staticDir });
 
   mainWindow = new BrowserWindow({
     width: 800,
@@ -21,7 +22,7 @@ function createWindow() {
       contextIsolation: true,
     },
   });
-  mainWindow.loadURL(`http://localhost:${port}`);
+  mainWindow.loadURL(`http://${host}:${port}`);
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const os = require('os');
 function startServer(options = {}) {
   const app = express();
   const port = options.port || process.env.PORT || 3000;
+  const host = options.host || process.env.HOST || '127.0.0.1';
   const appDir = options.appDir || path.join(__dirname, 'public');
   const staticDir =
     options.staticDir || path.join(os.homedir(), 'clocl_wallpapers');
@@ -75,8 +76,8 @@ function startServer(options = {}) {
     });
   });
 
-  return app.listen(port, () => {
-    console.log(`Server running on http://localhost:${port}`);
+  return app.listen(port, host, () => {
+    console.log(`Server running on http://${host}:${port}`);
   });
 }
 


### PR DESCRIPTION
## Summary
- bind the express server to `127.0.0.1` by default
- update Electron launcher to use localhost address
- document the change in README

## Testing
- `npm install`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_6844085c256c8321901deb2ab0ff0c4f