### PR TITLE
Bundle font at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ public/static/*.jpg
 public/static/*.jpeg
 public/static/*.gif
 dist/
+public/fonts/

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ change the slideshow without rebuilding.
 Your saved settings will be read from the same data directory used in
 development, so preferences carry over to the packaged app.
 
+The build scripts also fetch the **Kaisei Decol** font automatically. This
+font is bundled into `public/fonts` so the app can display text offline even if
+Google Fonts is unreachable.
+
 ### Dependency notes
 
 The build uses recent versions of Electron and electron-builder. Some

--- a/compile.bat
+++ b/compile.bat
@@ -4,6 +4,16 @@
 rem Build a portable Electron app for Windows
 set "CSC_IDENTITY_AUTO_DISCOVERY=false"
 
+set "FONT_DIR=public\fonts"
+set "FONT_FILE=%FONT_DIR%\KaiseiDecol-Regular.ttf"
+set "FONT_URL=https://fonts.gstatic.com/s/kaiseidecol/v10/bMrwmSqP45sidWf3QmfFW6iyWw.ttf"
+
+if not exist "%FONT_DIR%" mkdir "%FONT_DIR%"
+if not exist "%FONT_FILE%" (
+  echo Downloading Kaisei Decol font...
+  powershell -Command "Invoke-WebRequest -Uri %FONT_URL% -OutFile %FONT_FILE%"
+)
+
 npm install
 
 npx electron-builder --win portable

--- a/compile.sh
+++ b/compile.sh
@@ -1,4 +1,17 @@
 #!/bin/sh
 # Build a portable Electron app for Linux/macOS
+set -e
+
+# Download Kaisei Decol font for offline use if it isn't present
+FONT_DIR="public/fonts"
+FONT_FILE="$FONT_DIR/KaiseiDecol-Regular.ttf"
+FONT_URL="https://fonts.gstatic.com/s/kaiseidecol/v10/bMrwmSqP45sidWf3QmfFW6iyWw.ttf"
+
+mkdir -p "$FONT_DIR"
+if [ ! -f "$FONT_FILE" ]; then
+  echo "Downloading Kaisei Decol font..."
+  curl -L -o "$FONT_FILE" "$FONT_URL"
+fi
+
 npm install
 npx electron-builder --linux AppImage

--- a/public/index.html
+++ b/public/index.html
@@ -7,6 +7,12 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Kaisei+Decol&family=M+PLUS+Rounded+1c&family=Noto+Sans+JP:wght@100..900&family=Noto+Serif+JP:wght@200..900&family=Zen+Kaku+Gothic+New&family=Zen+Maru+Gothic&display=swap" rel="stylesheet">
   <style>
+    @font-face {
+      font-family: "Kaisei Decol Local";
+      src: url("/fonts/KaiseiDecol-Regular.ttf") format("truetype");
+      font-weight: 400;
+      font-style: normal;
+    }
     html, body {
       margin: 0; padding: 0;
       height: 100%; width: 100%;
@@ -43,7 +49,7 @@
       font-style: normal;
     }
     .kaisei-decol-regular {
-      font-family: "Kaisei Decol", serif;
+      font-family: "Kaisei Decol Local", "Kaisei Decol", serif;
       font-weight: 400;
       font-style: normal;
     }


### PR DESCRIPTION
## Summary
- keep repo slim by removing `KaiseiDecol-Regular.ttf`
- ignore downloaded font files
- download Kaisei Decol font in `compile.sh` and `compile.bat`
- mention automatic font download in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68440d474f8083219a590f580475b726